### PR TITLE
Send credentials when talking to robotoff and OFF

### DIFF
--- a/src/Ingredients/index.js
+++ b/src/Ingredients/index.js
@@ -21,6 +21,7 @@ const Ingredients = () => {
       `${
         process.env.REACT_APP_OFF_BASE
       }/cgi/ingredients.pl?code=${code}&id=ingredients_fr&process_image=1&ocr_engine=google_cloud_vision`,
+      { withCredentials: true },
     );
     if (!ingredients_text_from_image) {
       return '';
@@ -32,6 +33,7 @@ const Ingredients = () => {
         process.env.REACT_APP_ROBOTOFF_BASE
       }/api/v1/predict/ingredients/spellcheck`,
       new URLSearchParams(`text=${ingredients_text_from_image}`),
+      { withCredentials: true },
     );
     return corrected || text;
   };
@@ -44,6 +46,7 @@ const Ingredients = () => {
       `${
         process.env.REACT_APP_OFF_BASE
       }/state/photos-validated/state/ingredients-to-be-completed.json?fields=null`,
+      { withCredentials: true },
     ); // TODO: should be done only one times
     const randomPage = Math.floor((Math.random() * count) / page_size);
     const {
@@ -52,6 +55,7 @@ const Ingredients = () => {
       `${
         process.env.REACT_APP_OFF_BASE
       }/state/photos-validated/state/ingredients-to-be-completed/${randomPage}.json`,
+      { withCredentials: true },
     );
     const ingredientsResults = await axios.all(
       // 20 parallels request will be to much
@@ -83,6 +87,7 @@ const Ingredients = () => {
         new URLSearchParams(
           `ingredients_text_fr=${ingredients}&code=${products[0].code}`,
         ),
+        { withCredentials: true },
       ); // The status of the response is not displayed so no need to wait the response
     }
     setValidateInput('');

--- a/src/Questions/index.js
+++ b/src/Questions/index.js
@@ -80,6 +80,7 @@ const Questions = () => {
       }&lang=${subDomain.languageCode}&count=5${
         brands ? `&brands=${brands}` : ''
       }${`&insight_types=${selectedInsights.join(',')}`}`,
+      { withCredentials: true },
     )
       .then(({ data }) => {
         questionsResults = data.questions
@@ -101,6 +102,7 @@ const Questions = () => {
               }.openfoodfacts.org/api/v0/product/${
                 q.barcode
               }.json?fields=product_name`,
+              { withCredentials: true },
             ),
           ),
         );
@@ -128,6 +130,7 @@ const Questions = () => {
           questions[0].insight_id
         }&annotation=${annotation}&update=1`,
       ),
+      { withCredentials: true },
     ); // The status of the response is not displayed so no need to wait the response
     setQuestions(questions.filter((_, i) => i)); // remove first question
   };


### PR DESCRIPTION
Basically the same as openfoodfacts/openfoodfacts-server#2625:
@raphael0202 would like to add user authentication for robotoff to enable attribution. To force browsers to send their session cookie to the robotoff subdomain, the `axios` statements need to be modified.

Fixes #13