### PR TITLE
Fix incorrect fiber field name

### DIFF
--- a/src/NutritionValues/nutriments.js
+++ b/src/NutritionValues/nutriments.js
@@ -5,6 +5,6 @@ export default {
   Carbs: 'nutriment_carbohydrates',
   Sugar: 'nutriment_sugars',
   Proteins: 'nutriment_proteins',
-  Fibers: 'nutriment_fibers',
+  Fibers: 'nutriment_fiber',
   Salt: 'nutriment_salt',
 };


### PR DESCRIPTION
Nutrient values were not added, as the field name was incorrect (see https://en.wiki.openfoodfacts.org/API/Write#Add_the_nutrition_facts)